### PR TITLE
Added dark theme for forget password page

### DIFF
--- a/Frontend/src/Components/AuthModule/ForgetPassModule/ForgetPassword.module.css
+++ b/Frontend/src/Components/AuthModule/ForgetPassModule/ForgetPassword.module.css
@@ -172,6 +172,22 @@ input:not(:placeholder-shown) + .necessary{
 .footer a:hover {
     text-decoration: underline;
 }
+/* Dark Theme Support */
+:global(.dark-theme) .card {
+    
+    background: rgba(39, 39, 39, 0.266);
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+     background-image: url("data:image/svg+xml,%3csvg width='541' height='249' viewBox='0 0 541 249' xmlns='http://www.w3.org/2000/svg'%3e%3crect x='0.5' y='0.5' width='540' height='248' rx='14.83' ry='14.83' fill='none' stroke='%23606CA1' stroke-width='1' stroke-dasharray='6%2c 6' stroke-dashoffset='0' stroke-linecap='round'/%3e%3c/svg%3e");
+   
+}
+:global(.dark-theme) .field input {
+    background: rgba(173, 173, 173, 0.28);
+    color: #fff;
+}
+:global(.dark-theme) .field input::placeholder {
+    color: #ccc;
+}
 /*.container::-webkit-scrollbar {
     display: none;
 }


### PR DESCRIPTION
# Description  
Implemented the dark theme for forget password page based on the provided figma design . 

---

## Type of Change  
<!-- Check the box that best describes your change. -->  
- [ ] 🆕 New Feature  
- [ ] 🐛 Bug Fix  
- [ ] 🖼 Wallpaper Added 
- [X] 🎨 UI/Design Update  
- [ ] 🔄 Refactor/Code Improvement  
- [ ] 📂 Other (Specify here):  

**Issue Linked:**   Fixes #233 

---

# Checklist  
- [X] 📖 I have read and followed the [Contributing Guidelines](CONTRIBUTING.md).  
- [X] ✅ My code adheres to the project's style guidelines.  
- [X] 🧪 I have tested my changes locally and ensured no existing functionality is broken.  
- [X] ✍️ I have added or updated necessary documentation where applicable (e.g., README.md, DESIGN.md, WALLPAPER.md).  

---

