### PR TITLE
Add dark mode support to Sign In page

### DIFF
--- a/Frontend/src/Components/AuthModule/SignInModule/SignIn.module.css
+++ b/Frontend/src/Components/AuthModule/SignInModule/SignIn.module.css
@@ -382,3 +382,119 @@
         width: 100%;
     }
 }
+
+/* ========================================
+   DARK MODE STYLES
+   ======================================== */
+
+:global(.dark-theme) .container {
+    background-image: url('/Dark_mode_bg.webp');
+}
+
+:global(.dark-theme) .title {
+    color: #FFFFFF;
+}
+
+:global(.dark-theme) .subtitle {
+    color: #ccc;
+}
+
+/* Dark mode card with darker, semi-transparent background and lighter border */
+:global(.dark-theme) .signInCard {
+    background-color: rgba(39, 39, 39, 0.266);
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+    /* Card Border: 1px dashed with light color for dark mode */
+    background-image: url("data:image/svg+xml,%3csvg width='541' height='555' viewBox='0 0 541 555' xmlns='http://www.w3.org/2000/svg'%3e%3crect x='0.5' y='0.5' width='540' height='554' rx='14.83' ry='14.83' fill='none' stroke='%23606CA1' stroke-width='1' stroke-dasharray='6%2c 6' stroke-dashoffset='0' stroke-linecap='round'/%3e%3c/svg%3e");
+}
+
+/* Dark mode social buttons */
+:global(.dark-theme) .socialButton {
+    background-color: transparent;
+    color: #ccc;
+    /* Dark mode border for social buttons */
+    background-image: url("data:image/svg+xml,%3csvg width='142' height='40' viewBox='0 0 142 40' xmlns='http://www.w3.org/2000/svg'%3e%3crect x='0.5' y='0.5' width='141' height='39' rx='10' ry='10' fill='none' stroke='%23606CA1' stroke-width='1' stroke-dasharray='3%2c 3' stroke-dashoffset='0' stroke-linecap='round'/%3e%3c/svg%3e");
+}
+
+:global(.dark-theme) .socialButton:hover {
+    background-color: rgba(100, 120, 200, 0.2);
+}
+
+/* Dark SVG icons in social buttons - override inline stroke colors */
+:global(.dark-theme) .socialButton svg circle {
+    stroke: #ccc !important;
+}
+
+:global(.dark-theme) .socialButton svg path {
+    stroke: #ccc !important;
+}
+
+:global(.dark-theme) .socialButton svg rect {
+    stroke: #ccc !important;
+}
+
+/* Dark mode divider */
+:global(.dark-theme) .divider span {
+    color: rgba(96, 96, 96, 1);
+}
+
+/* Dark mode label */
+:global(.dark-theme) .label {
+    color: #ccc;
+}
+
+/* Dark mode input fields */
+:global(.dark-theme) .input {
+    background: rgba(173, 173, 173, 0.28);
+    border: 2px solid transparent;
+    color: #fff;
+}
+
+:global(.dark-theme) .input::placeholder {
+    color: #ccc;
+}
+
+:global(.dark-theme) .input:focus {
+    border-color: #6B7FE0;
+    background: rgba(173, 173, 173, 0.35);
+}
+
+/* Dark mode autofill styling */
+:global(.dark-theme) .input:-webkit-autofill,
+:global(.dark-theme) .input:-webkit-autofill:hover,
+:global(.dark-theme) .input:-webkit-autofill:focus,
+:global(.dark-theme) .input:-webkit-autofill:active {
+    -webkit-box-shadow: 0 0 0 1000px rgba(173, 173, 173, 0.28) inset !important;
+    box-shadow: 0 0 0 1000px rgba(173, 173, 173, 0.28) inset !important;
+    -webkit-text-fill-color: #fff !important;
+}
+
+/* Dark mode forgot password link */
+:global(.dark-theme) .forgotPassword {
+    color: #A0B0D0;
+}
+
+:global(.dark-theme) .forgotPassword:hover {
+    color: #6B7FE0;
+}
+
+/* Dark mode sign in button */
+:global(.dark-theme) .signInButton {
+    background-color: #5F71FE;
+    box-shadow: 0 4px 12px rgba(95, 113, 254, 0.2);
+}
+
+:global(.dark-theme) .signInButton:hover {
+    background: #7080FF;
+    box-shadow: 0 4px 16px rgba(95, 113, 254, 0.4);
+}
+
+/* Dark mode sign up text */
+:global(.dark-theme) .signUpText {
+    color: #B0B0B0;
+}
+
+/* Dark mode sign up link */
+:global(.dark-theme) .signUpLink {
+    color: #7080FF;
+}

--- a/Frontend/src/Components/HomeModule/Home.jsx
+++ b/Frontend/src/Components/HomeModule/Home.jsx
@@ -1,8 +1,10 @@
 import NavBar from "../CommonModule/NavBarModule/NavBar";
 import Footer from "../CommonModule/FooterModule/Footer";
 import Styles from "./Home.module.css";
+import { useNavigate } from "react-router-dom";
 
 const Home = () => {
+    const navigate = useNavigate();
     return (
         <>
             <div className={Styles.navbarWrapper}>
@@ -47,6 +49,22 @@ const Home = () => {
                 <div className={Styles.footerWrapper}>
                     <Footer />
                 </div>
+{/*             
+                <button 
+                    onClick={() => navigate("/signin")}
+                    style={{
+                        marginTop: "20px",
+                        padding: "10px 20px",
+                        fontSize: "16px",
+                        cursor: "pointer",
+                        backgroundColor: "#007bff",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "4px"
+                    }}
+                >
+                    Sign In (Test)
+                </button> */}
             </div>
         </>
     );


### PR DESCRIPTION
## Description
Implement dark mode support for the Sign In authentication page to ensure visual consistency across all authentication components. The Sign In page now automatically detects and applies the user's theme preference while maintaining design system consistency with the Sign Up page dark theme.

## Type of Change
- [x] 🎨 UI/Design Update
- [ ] 🆕 New Feature
- [ ] 🐛 Bug Fix
- [ ] 🖼 Wallpaper Added
- [ ] 🔄 Refactor/Code Improvement
- [ ] 📂 Other (Specify here):

## Issue Linked:
#234 

## Changes Made
- Updated Sign In card styling with dark theme colors (`rgba(39, 39, 39, 0.266)`)
- Changed card border color to `#606CA1` for dark mode consistency
- Fixed social button (Google, GitHub, Microsoft) icon visibility in dark mode
- Updated input field styling: background `rgba(173, 173, 173, 0.28)` with white text
- Adjusted all text colors (labels, placeholders, links) for proper readability
- Ensured automatic dark mode activation based on localStorage theme preference

## Checklist
- [x] 📖 I have read and followed the Contributing Guidelines.
- [x] ✅ My code adheres to the project's style guidelines.
- [x] 🧪 I have tested my changes locally and ensured no existing functionality is broken.
- [x] ✍️ I have added or updated necessary documentation where applicable.

## Additional Notes
The dark mode styling has been aligned with the existing Sign Up component to maintain consistency across authentication pages. The theme is controlled by the global ThemeToggle component and respects the user's localStorage preference for automatic activation on page load.

All social button SVG icons now properly display in light gray (`#ccc`) with appropriate contrast against the dark background.