### PR TITLE
refactor: remove overlapping media query and adjust tablet breakpoint

### DIFF
--- a/Frontend/src/Components/CommonModule/NavBarModule/NavBar.module.css
+++ b/Frontend/src/Components/CommonModule/NavBarModule/NavBar.module.css
@@ -251,7 +251,7 @@
     height: 100%;
 }
 
-/* Tablet Portrait + Landscape - Fixed dimensions like Footer */
+/* Tablet Portrait + Landscape */
 @media (min-width: 701px) and (max-width: 1195px) {
     .navbar {
         width: 43.125rem;


### PR DESCRIPTION
# Description  
This PR fixes an issue with overlapping media queries that caused inconsistent layout behavior on tablet screen sizes.

Previously, the project had these two media queries:
- `@media (min-width: 701px) and (max-width: 1024px)`
- `@media (max-width: 1100px)`

Because these ranges overlapped, tablet dimensions were not handled in a clear or ordered way, which could lead to unexpected styling conflicts.

### Changes made:
- Removed the `@media (max-width: 1100px)` media query.
- Updated the tablet breakpoint from  
  `@media (min-width: 701px) and (max-width: 1024px)`  
  to  
  `@media (min-width: 701px) and (max-width: 1195px)`.
- Updated the related CSS rules to ensure layouts render correctly within the revised breakpoint range.

These changes ensure responsive behavior is consistent and prevent styling conflicts across tablet and nearby screen sizes.

---

## Type of Change  
- [ ] 🆕 New Feature  
- [ ] 🐛 Bug Fix  
- [ ] 🖼 Wallpaper Added 
- [ ] 🎨 UI/Design Update  
- [X] 🔄 Refactor/Code Improvement  
- [ ] 📂 Other (Specify here):  

**Issue Linked:**  
Fixes #277 

---

# Checklist  
- [X] 📖 I have read and followed the [Contributing Guidelines](CONTRIBUTING.md).  
- [X] ✅ My code adheres to the project's style guidelines.  
- [X] 🧪 I have tested my changes locally and ensured no existing functionality is broken.  
- [X] ✍️ I have added or updated necessary documentation where applicable (e.g., README.md, DESIGN.md, WALLPAPER.md).  

---

# Additional Notes  
This change simplifies the responsive design logic and prevents styling conflicts caused by overlapping breakpoints.

https://github.com/user-attachments/assets/64d7a141-a05a-4ed8-9d0a-c6d04b1a2862